### PR TITLE
Update GitHub Actions to run flutter clean and upload APK to releases

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         flutter-version: '3.27.1'
 
+    - name: Clean the build directory
+      run: flutter clean
+
     - name: Install dependencies
       run: flutter pub get
 
@@ -35,3 +38,11 @@ jobs:
         mkdir -p release
         cp build/app/outputs/flutter-apk/app-release.apk release/
         echo "New release package created for Android"
+
+    - name: Upload APK to GitHub Releases
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: release/app-release.apk
+        asset_name: app-release.apk
+        asset_content_type: application/vnd.android.package-archive

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -15,6 +15,10 @@ key.properties
 # Flutter-related
 **/Flutter/ephemeral/
 **/Pods/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/
 
 # Xcode-related
 **/dgph


### PR DESCRIPTION
Add files deleted by 'flutter clean' to `.gitignore` and update GitHub Actions workflow.

* **.gitignore changes:**
  - Add `.dart_tool/` to ignore the `.dart_tool` directory.
  - Add `.flutter-plugins` to ignore the `.flutter-plugins` file.
  - Add `.flutter-plugins-dependencies` to ignore the `.flutter-plugins-dependencies` file.
  - Add `build/` to ignore the `build` directory.

* **GitHub Actions workflow changes:**
  - Add a step to run `flutter clean` before `flutter pub get`.
  - Add a step to upload the APK to GitHub releases after creating the release package.

