### PR TITLE
Fix upload_url parameter in GitHub Actions workflow

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,7 +1,7 @@
 name: Flutter CI
 
 on: 
-  pull_request:
+  push:
     branches:
       - main
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This mobile app allows users to track and manage the books they have read. Users
 - Works offline
 
 ## Current Build Version
-The current build version for Android is 1.0.0+1.
+The current build version for Android is 1.0.0+1. The APK build and release process is triggered only by merging to the `main` branch.
 
 ## Development Environment Setup
 
@@ -39,6 +39,8 @@ To set up the development environment for this project, follow these steps:
    ```sh
    flutter pub get
    ```
+
+All testing and new changes should be pushed to the `dev` branch.
 
 ## Running the App
 


### PR DESCRIPTION
Update the README.md and GitHub Actions workflow to trigger APK build and release process only on merging to the main branch.

* **README.md**
  - Update the "Current Build Version" section to mention that the APK build and release process is triggered only by merging to the `main` branch.
  - Update the "Development Environment Setup" section to mention that all testing and new changes should be pushed to the `dev` branch.

* **.github/workflows/flutter.yml**
  - Update the `on` section to trigger the workflow only on `push` events to the `main` branch.
  - Remove the `pull_request` trigger from the `on` section.

