### PR TITLE
Fix required parameter issues in BookDetailsScreen and BookListItem

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'screens/home_screen.dart';
 import 'screens/add_book_screen.dart';
 import 'screens/book_details_screen.dart';
 import 'screens/settings_screen.dart';
+import 'models/book.dart';
 
 void main() {
   runApp(MyApp());
@@ -21,7 +22,16 @@ class _MyAppState extends State<MyApp> {
   static const List<Widget> _widgetOptions = <Widget>[
     HomeScreen(),
     AddBookScreen(),
-    BookDetailsScreen(),
+    BookDetailsScreen(
+      book: Book(
+        title: 'Sample Book',
+        author: 'Sample Author',
+        isbn: '1234567890',
+        notes: 'Sample notes',
+        rating: 4.5,
+        readingProgress: 0.75,
+      ),
+    ),
     SettingsScreen(),
   ];
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});

--- a/lib/widgets/book_list_item.dart
+++ b/lib/widgets/book_list_item.dart
@@ -5,7 +5,7 @@ import '../screens/book_details_screen.dart';
 class BookListItem extends StatelessWidget {
   final Book book;
 
-  const BookListItem({super.key, @required this.book});
+  const BookListItem({super.key, required this.book});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Fix missing required parameters and import statements.

* **lib/main.dart**
  - Provide the required 'book' parameter in the `BookDetailsScreen` constructor.
  - Use a sample `Book` instance for the 'book' parameter.

* **lib/widgets/book_list_item.dart**
  - Add the 'required' modifier to the 'book' parameter in the `BookListItem` constructor.

* **lib/screens/settings_screen.dart**
  - Import the `BlockPicker` class from the `flutter_colorpicker` package.

