### PR TITLE
Fix test failures in HomeScreen and AddBookScreen

### DIFF
--- a/test/add_book_screen_test.dart
+++ b/test/add_book_screen_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_library_app/screens/add_book_screen.dart';
+import 'package:flutter_library_app/services/book_service.dart';
+import 'package:flutter_library_app/models/book.dart';
 
 void main() {
   testWidgets('AddBookScreen has a title and form fields', (WidgetTester tester) async {
@@ -36,6 +38,7 @@ void main() {
   });
 
   testWidgets('AddBookScreen adds a book and navigates back', (WidgetTester tester) async {
+    final bookService = BookService();
     await tester.pumpWidget(MaterialApp(home: AddBookScreen()));
 
     // Enter text into the form fields
@@ -48,7 +51,15 @@ void main() {
     await tester.tap(find.text('Submit Book'));
     await tester.pumpAndSettle();
 
-    // Verify that the book was added and the screen navigated back
+    // Verify that the book was added
+    final books = await bookService.getBooks();
+    expect(books.length, 1);
+    expect(books.first.title, 'Test Book');
+    expect(books.first.author, 'Test Author');
+    expect(books.first.isbn, '1234567890');
+    expect(books.first.notes, 'Test notes');
+
+    // Verify that the screen navigated back
     expect(find.text('Add Book'), findsNothing);
   });
 }

--- a/test/home_screen_test.dart
+++ b/test/home_screen_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_library_app/screens/home_screen.dart';
+import 'package:flutter_library_app/models/book.dart';
+import 'package:flutter_library_app/services/book_service.dart';
 
 void main() {
   testWidgets('HomeScreen has a title and search field', (WidgetTester tester) async {
@@ -24,6 +26,17 @@ void main() {
   });
 
   testWidgets('HomeScreen filters books based on search query', (WidgetTester tester) async {
+    final bookService = BookService();
+    final sampleBook = Book(
+      title: 'Sample Book',
+      author: 'Sample Author',
+      isbn: '1234567890',
+      notes: 'Sample notes',
+      rating: 4.5,
+      readingProgress: 0.75,
+    );
+    await bookService.addBook(sampleBook);
+
     await tester.pumpWidget(MaterialApp(home: HomeScreen()));
 
     // Enter a search query


### PR DESCRIPTION
Update tests for HomeScreen and AddBookScreen to fix test failures.

* **HomeScreen Test**
  - Add a sample book to the list of books in the test 'HomeScreen filters books based on search query'.
  - Verify that the sample book is displayed when the search query matches the book title.

* **AddBookScreen Test**
  - Add a book service to the test 'AddBookScreen adds a book and navigates back'.
  - Verify that the book is added by checking the book details.
  - Verify that the screen navigates back by ensuring the 'Add Book' widget is not found after the book is added.

