### PR TITLE
Fix NetworkImageLoadException by adding error handling and local placeholder image

### DIFF
--- a/lib/widgets/book_list_item.dart
+++ b/lib/widgets/book_list_item.dart
@@ -10,11 +10,20 @@ class BookListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: Image.network(
-        'https://via.placeholder.com/50', // Placeholder image URL
+      leading: FadeInImage.assetNetwork(
+        placeholder: 'assets/images/placeholder.png', // Local placeholder image
+        image: 'https://via.placeholder.com/50', // Placeholder image URL
         width: 50,
         height: 50,
         fit: BoxFit.cover,
+        imageErrorBuilder: (context, error, stackTrace) {
+          return Image.asset(
+            'assets/images/placeholder.png', // Local placeholder image
+            width: 50,
+            height: 50,
+            fit: BoxFit.cover,
+          );
+        },
       ),
       title: Text(book.title),
       subtitle: Column(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,9 +63,8 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
+  assets:
+    - assets/images/placeholder.png
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/to/resolution-aware-images


### PR DESCRIPTION
Add error handling for `NetworkImage` to display a local placeholder image in case of a network error.

* **lib/widgets/book_list_item.dart**
  - Replace `Image.network` with `FadeInImage.assetNetwork` to use a local placeholder image.
  - Add `imageErrorBuilder` to handle network errors and display the local placeholder image.

* **pubspec.yaml**
  - Add the local placeholder image asset under the `assets` section.

