### PR TITLE
Update buttons and tiles to be full width

### DIFF
--- a/lib/screens/add_book_screen.dart
+++ b/lib/screens/add_book_screen.dart
@@ -146,18 +146,36 @@ class _AddBookScreenState extends State<AddBookScreen> {
                 },
               ),
               SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: _searchForBook,
-                child: Text('Search for Book'),
+              Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: _searchForBook,
+                      child: Text('Search for Book'),
+                    ),
+                  ),
+                ],
               ),
-              ElevatedButton(
-                onPressed: _scanBarcode,
-                child: Text('Scan Barcode'),
+              Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: _scanBarcode,
+                      child: Text('Scan Barcode'),
+                    ),
+                  ),
+                ],
               ),
               SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: _addBook,
-                child: Text('Submit Book'),
+              Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: _addBook,
+                      child: Text('Submit Book'),
+                    ),
+                  ),
+                ],
               ),
             ],
           ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -65,7 +65,10 @@ class _HomeScreenState extends State<HomeScreen> {
             child: ListView.builder(
               itemCount: filteredBooks.length,
               itemBuilder: (context, index) {
-                return BookListItem(book: filteredBooks[index]);
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+                  child: BookListItem(book: filteredBooks[index]),
+                );
               },
             ),
           ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -33,13 +33,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: <Widget>[
-            ElevatedButton(
-              onPressed: _exportLibrary,
-              child: Text('Export Library'),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _exportLibrary,
+                    child: Text('Export Library'),
+                  ),
+                ),
+              ],
             ),
-            ElevatedButton(
-              onPressed: _importLibrary,
-              child: Text('Import Library'),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: _importLibrary,
+                    child: Text('Import Library'),
+                  ),
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/widgets/book_list_item.dart
+++ b/lib/widgets/book_list_item.dart
@@ -8,26 +8,42 @@ class BookListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      leading: book.imageUrl != null && book.imageUrl!.isNotEmpty
-          ? FadeInImage.assetNetwork(
-              placeholder: 'assets/images/placeholder.png', // Local placeholder image
-              image: book.imageUrl!,
-              width: 50,
-              height: 50,
-              fit: BoxFit.cover,
-              imageErrorBuilder: (context, error, stackTrace) {
-                return Image.asset(
-                  'assets/images/placeholder.png', // Local placeholder image
-                  width: 50,
-                  height: 50,
-                  fit: BoxFit.cover,
-                );
-              },
-            )
-          : SizedBox(width: 50, height: 50), // Empty space when there is no image
-      title: Text(book.title),
-      subtitle: Text(book.author),
+    return Container(
+      padding: const EdgeInsets.all(8.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8.0),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.withOpacity(0.5),
+            spreadRadius: 2,
+            blurRadius: 5,
+            offset: Offset(0, 3),
+          ),
+        ],
+      ),
+      width: double.infinity,
+      child: ListTile(
+        leading: book.imageUrl != null && book.imageUrl!.isNotEmpty
+            ? FadeInImage.assetNetwork(
+                placeholder: 'assets/images/placeholder.png', // Local placeholder image
+                image: book.imageUrl!,
+                width: 50,
+                height: 50,
+                fit: BoxFit.cover,
+                imageErrorBuilder: (context, error, stackTrace) {
+                  return Image.asset(
+                    'assets/images/placeholder.png', // Local placeholder image
+                    width: 50,
+                    height: 50,
+                    fit: BoxFit.cover,
+                  );
+                },
+              )
+            : SizedBox(width: 50, height: 50), // Empty space when there is no image
+        title: Text(book.title),
+        subtitle: Text(book.author),
+      ),
     );
   }
 }


### PR DESCRIPTION
Update buttons and tiles to be full width and styled as tiles.

* **Home Screen**
  - Update `BookListItem` widget to use `Expanded` widget for full width.
  - Add padding to `BookListItem` widget to make it look like a tile.

* **Add Book Screen**
  - Update the search button to use `Expanded` widget for full width.
  - Update the scan barcode button to use `Expanded` widget for full width.
  - Update the submit button to use `Expanded` widget for full width.

* **Settings Screen**
  - Update the export library button to use `Expanded` widget for full width.
  - Update the import library button to use `Expanded` widget for full width.

* **Book List Item Widget**
  - Wrap `ListTile` widget with a `Container` widget.
  - Add `padding` and `decoration` properties to the `Container` widget to make it look like a tile.
  - Set the `width` property of the `Container` widget to `double.infinity` to make it full width.

