### PR TITLE
Add year, description, and image to book details

### DIFF
--- a/lib/models/book.dart
+++ b/lib/models/book.dart
@@ -3,12 +3,16 @@ class Book {
   String author;
   String isbn;
   String? imageUrl;
+  int? year;
+  String? description;
 
   Book({
     required this.title,
     required this.author,
     required this.isbn,
     this.imageUrl,
+    this.year,
+    this.description,
   });
 
   factory Book.fromJson(Map<String, dynamic> json) {
@@ -17,6 +21,8 @@ class Book {
       author: json['author'],
       isbn: json['isbn'],
       imageUrl: json['imageUrl'],
+      year: json['year'],
+      description: json['description'],
     );
   }
 
@@ -26,6 +32,8 @@ class Book {
       'author': author,
       'isbn': isbn,
       'imageUrl': imageUrl,
+      'year': year,
+      'description': description,
     };
   }
 }

--- a/lib/screens/add_book_screen.dart
+++ b/lib/screens/add_book_screen.dart
@@ -17,6 +17,8 @@ class _AddBookScreenState extends State<AddBookScreen> {
   final _titleController = TextEditingController();
   final _authorController = TextEditingController();
   final _isbnController = TextEditingController();
+  final _yearController = TextEditingController();
+  final _descriptionController = TextEditingController();
   final BookService _bookService = BookService();
 
   @override
@@ -24,6 +26,8 @@ class _AddBookScreenState extends State<AddBookScreen> {
     _titleController.dispose();
     _authorController.dispose();
     _isbnController.dispose();
+    _yearController.dispose();
+    _descriptionController.dispose();
     super.dispose();
   }
 
@@ -45,6 +49,8 @@ class _AddBookScreenState extends State<AddBookScreen> {
           _titleController.text = bookData['title'] ?? '';
           _authorController.text = bookData['authors']?.join(', ') ?? '';
           _isbnController.text = bookData['industryIdentifiers']?.firstWhere((id) => id['type'] == 'ISBN_13', orElse: () => null)?['identifier'] ?? '';
+          _yearController.text = bookData['publishedDate']?.split('-')?.first ?? '';
+          _descriptionController.text = bookData['description'] ?? '';
         });
         _showSuccessMessage('Book details updated successfully!');
       } else {
@@ -93,6 +99,8 @@ class _AddBookScreenState extends State<AddBookScreen> {
         title: _titleController.text,
         author: _authorController.text,
         isbn: _isbnController.text,
+        year: int.tryParse(_yearController.text),
+        description: _descriptionController.text,
       );
       try {
         await _bookService.addBook(book);
@@ -141,6 +149,26 @@ class _AddBookScreenState extends State<AddBookScreen> {
                 validator: (value) {
                   if (value?.isEmpty ?? true) {
                     return 'Please enter the ISBN';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                controller: _yearController,
+                decoration: InputDecoration(labelText: 'Year'),
+                validator: (value) {
+                  if (value?.isEmpty ?? true) {
+                    return 'Please enter the year';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                controller: _descriptionController,
+                decoration: InputDecoration(labelText: 'Description'),
+                validator: (value) {
+                  if (value?.isEmpty ?? true) {
+                    return 'Please enter the description';
                   }
                   return null;
                 },

--- a/lib/services/book_service.dart
+++ b/lib/services/book_service.dart
@@ -76,6 +76,8 @@ class BookService {
           title: bookData['title'] ?? '',
           author: bookData['authors']?.join(', ') ?? '',
           isbn: bookData['industryIdentifiers']?.firstWhere((id) => id['type'] == 'ISBN_13', orElse: () => null)?['identifier'] ?? '',
+          year: int.tryParse(bookData['publishedDate']?.split('-')?.first ?? ''),
+          description: bookData['description'] ?? '',
         );
       }
     }

--- a/lib/widgets/book_list_item.dart
+++ b/lib/widgets/book_list_item.dart
@@ -40,9 +40,22 @@ class BookListItem extends StatelessWidget {
                   );
                 },
               )
-            : SizedBox(width: 50, height: 50), // Empty space when there is no image
+            : Image.asset(
+                'assets/images/placeholder.png', // Local placeholder image
+                width: 50,
+                height: 50,
+                fit: BoxFit.cover,
+              ),
         title: Text(book.title),
-        subtitle: Text(book.author),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(book.author),
+            if (book.year != null) Text('Year: ${book.year}'),
+            if (book.description != null && book.description!.isNotEmpty)
+              Text('Description: ${book.description}'),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
Add year and description fields to book details.

* **lib/models/book.dart**
  - Add `year` and `description` fields to `Book` class.
  - Update `Book.fromJson` and `Book.toJson` methods to handle new fields.

* **lib/screens/add_book_screen.dart**
  - Add `year` and `description` input fields to the form.
  - Update `_searchForBook` method to fetch `year` and `description` from API.
  - Update `_addBook` method to include `year` and `description` in `Book` object.

* **lib/services/book_service.dart**
  - Update `searchBookByNameOrISBN` method to fetch `year` and `description` from API.

* **lib/widgets/book_list_item.dart**
  - Update `BookListItem` widget to display `year` and `description` fields.
  - Use placeholder image from assets if no image is provided.

