### PR TITLE
Add book details screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'screens/home_screen.dart';
 import 'screens/add_book_screen.dart';
 import 'screens/settings_screen.dart';
+import 'screens/book_details_screen.dart'; // Import the new screen
 
 void main() {
   runApp(MyApp());
@@ -60,6 +61,9 @@ class _MyAppState extends State<MyApp> {
           onTap: _onItemTapped,
         ),
       ),
+      routes: {
+        '/bookDetails': (context) => BookDetailsScreen(book: ModalRoute.of(context)!.settings.arguments as Book),
+      },
     );
   }
 }

--- a/lib/models/book.dart
+++ b/lib/models/book.dart
@@ -5,6 +5,7 @@ class Book {
   String? imageUrl;
   int? year;
   String? description;
+  int? firstAppearanceYear; // Pc8c9
 
   Book({
     required this.title,
@@ -13,6 +14,7 @@ class Book {
     this.imageUrl,
     this.year,
     this.description,
+    this.firstAppearanceYear, // Pc8c9
   });
 
   factory Book.fromJson(Map<String, dynamic> json) {
@@ -23,6 +25,7 @@ class Book {
       imageUrl: json['imageUrl'],
       year: json['year'],
       description: json['description'],
+      firstAppearanceYear: json['firstAppearanceYear'], // P897a
     );
   }
 
@@ -34,6 +37,7 @@ class Book {
       'imageUrl': imageUrl,
       'year': year,
       'description': description,
+      'firstAppearanceYear': firstAppearanceYear, // P7bf5
     };
   }
 }

--- a/lib/screens/add_book_screen.dart
+++ b/lib/screens/add_book_screen.dart
@@ -101,6 +101,7 @@ class _AddBookScreenState extends State<AddBookScreen> {
         isbn: _isbnController.text,
         year: int.tryParse(_yearController.text),
         description: _descriptionController.text,
+        firstAppearanceYear: int.tryParse(_yearController.text), // P83b7
       );
       try {
         await _bookService.addBook(book);

--- a/lib/screens/book_details_screen.dart
+++ b/lib/screens/book_details_screen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import '../models/book.dart';
+
+class BookDetailsScreen extends StatelessWidget {
+  final Book book;
+
+  const BookDetailsScreen({super.key, required this.book});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(book.title),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            if (book.imageUrl != null)
+              Center(
+                child: Image.network(book.imageUrl!),
+              ),
+            SizedBox(height: 16.0),
+            Text(
+              'Title: ${book.title}',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 8.0),
+            Text(
+              'Author: ${book.author}',
+              style: TextStyle(fontSize: 18),
+            ),
+            SizedBox(height: 8.0),
+            if (book.year != null)
+              Text(
+                'Year: ${book.year}',
+                style: TextStyle(fontSize: 18),
+              ),
+            SizedBox(height: 8.0),
+            if (book.firstAppearanceYear != null)
+              Text(
+                'First Appearance Year: ${book.firstAppearanceYear}',
+                style: TextStyle(fontSize: 18),
+              ),
+            SizedBox(height: 8.0),
+            if (book.description != null)
+              Text(
+                'Description: ${book.description}',
+                style: TextStyle(fontSize: 16),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/book_list_item.dart
+++ b/lib/widgets/book_list_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/book.dart';
+import '../screens/book_details_screen.dart';
 
 class BookListItem extends StatelessWidget {
   final Book book;
@@ -8,53 +9,39 @@ class BookListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(8.0),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(8.0),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.grey.withOpacity(0.5),
-            spreadRadius: 2,
-            blurRadius: 5,
-            offset: Offset(0, 3),
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => BookDetailsScreen(book: book),
           ),
-        ],
-      ),
-      width: double.infinity,
-      child: ListTile(
-        leading: book.imageUrl != null && book.imageUrl!.isNotEmpty
-            ? FadeInImage.assetNetwork(
-                placeholder: 'assets/images/placeholder.png', // Local placeholder image
-                image: book.imageUrl!,
-                width: 50,
-                height: 50,
-                fit: BoxFit.cover,
-                imageErrorBuilder: (context, error, stackTrace) {
-                  return Image.asset(
-                    'assets/images/placeholder.png', // Local placeholder image
-                    width: 50,
-                    height: 50,
-                    fit: BoxFit.cover,
-                  );
-                },
-              )
-            : Image.asset(
-                'assets/images/placeholder.png', // Local placeholder image
-                width: 50,
-                height: 50,
-                fit: BoxFit.cover,
-              ),
-        title: Text(book.title),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(book.author),
-            if (book.year != null) Text('Year: ${book.year}'),
-            if (book.description != null && book.description!.isNotEmpty)
-              Text('Description: ${book.description}'),
+        );
+      },
+      child: Container(
+        padding: const EdgeInsets.all(8.0),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(8.0),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.grey.withOpacity(0.5),
+              spreadRadius: 2,
+              blurRadius: 5,
+              offset: Offset(0, 3),
+            ),
           ],
+        ),
+        width: double.infinity,
+        child: ListTile(
+          title: Text(book.title),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(book.author),
+              if (book.year != null) Text('Year: ${book.year}'),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Update the book list item to show only title, author, and year, and add navigation to book details screen.

* **BookListItem widget**: Update to show only title, author, and year. Add onTap callback to navigate to book details screen.
* **Book class**: Add firstAppearanceYear field. Update fromJson and toJson methods to handle firstAppearanceYear.
* **AddBookScreen**: Update _addBook method to include firstAppearanceYear field.
* **BookDetailsScreen**: Create new screen to display book details including full description and other book data.
* **Main.dart**: Add route for book details screen.

