### PR TITLE
Fix description scroll in book details screen

### DIFF
--- a/lib/screens/book_details_screen.dart
+++ b/lib/screens/book_details_screen.dart
@@ -45,9 +45,14 @@ class BookDetailsScreen extends StatelessWidget {
               ),
             SizedBox(height: 8.0),
             if (book.description != null)
-              Text(
-                'Description: ${book.description}',
-                style: TextStyle(fontSize: 16),
+              SingleChildScrollView(
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 16.0),
+                  child: Text(
+                    'Description: ${book.description}',
+                    style: TextStyle(fontSize: 16),
+                  ),
+                ),
               ),
           ],
         ),


### PR DESCRIPTION
Wrap the book description text in a `SingleChildScrollView` to make it scrollable if it is longer than the viewport.

* Add a `Padding` widget with a bottom margin to the `SingleChildScrollView` to ensure proper spacing.
