### PR TITLE
Update book details to use publishedDate and industryIdentifiers

### DIFF
--- a/lib/models/book.dart
+++ b/lib/models/book.dart
@@ -3,29 +3,27 @@ class Book {
   String author;
   String isbn;
   String? imageUrl;
-  int? year;
+  int? publishedDate;
   String? description;
-  int? firstAppearanceYear;
 
   Book({
     required this.title,
     required this.author,
     required this.isbn,
     this.imageUrl,
-    this.year,
+    this.publishedDate,
     this.description,
-    this.firstAppearanceYear,
   });
 
   factory Book.fromJson(Map<String, dynamic> json) {
     return Book(
       title: json['title'],
       author: json['author'],
-      isbn: json['isbn'],
+      isbn: (json['industryIdentifiers'] as List<dynamic>?)
+          ?.firstWhere((id) => id['type'] == 'ISBN_13', orElse: () => null)?['identifier'] ?? '',
       imageUrl: json['imageUrl'],
-      year: json['year'],
+      publishedDate: json['publishedDate'],
       description: json['description'],
-      firstAppearanceYear: json['firstAppearanceYear'],
     );
   }
 
@@ -35,14 +33,13 @@ class Book {
       'author': author,
       'isbn': isbn,
       'imageUrl': imageUrl,
-      'year': year,
+      'publishedDate': publishedDate,
       'description': description,
-      'firstAppearanceYear': firstAppearanceYear,
     };
   }
 
   @override
   String toString() {
-    return 'Book{title: $title, author: $author, isbn: $isbn, imageUrl: $imageUrl, year: $year, description: $description, firstAppearanceYear: $firstAppearanceYear}';
+    return 'Book{title: $title, author: $author, isbn: $isbn, imageUrl: $imageUrl, publishedDate: $publishedDate, description: $description}';
   }
 }

--- a/lib/screens/add_book_screen.dart
+++ b/lib/screens/add_book_screen.dart
@@ -17,7 +17,7 @@ class _AddBookScreenState extends State<AddBookScreen> {
   final _titleController = TextEditingController();
   final _authorController = TextEditingController();
   final _isbnController = TextEditingController();
-  final _yearController = TextEditingController();
+  final _publishedDateController = TextEditingController();
   final _descriptionController = TextEditingController();
   final BookService _bookService = BookService();
 
@@ -26,7 +26,7 @@ class _AddBookScreenState extends State<AddBookScreen> {
     _titleController.dispose();
     _authorController.dispose();
     _isbnController.dispose();
-    _yearController.dispose();
+    _publishedDateController.dispose();
     _descriptionController.dispose();
     super.dispose();
   }
@@ -49,7 +49,7 @@ class _AddBookScreenState extends State<AddBookScreen> {
           _titleController.text = bookData['title'] ?? '';
           _authorController.text = bookData['authors']?.join(', ') ?? '';
           _isbnController.text = bookData['industryIdentifiers']?.firstWhere((id) => id['type'] == 'ISBN_13', orElse: () => null)?['identifier'] ?? '';
-          _yearController.text = bookData['publishedDate']?.split('-')?.first ?? '';
+          _publishedDateController.text = bookData['publishedDate']?.split('-')?.first ?? '';
           _descriptionController.text = bookData['description'] ?? '';
         });
         _showSuccessMessage('Book details updated successfully!');
@@ -99,9 +99,8 @@ class _AddBookScreenState extends State<AddBookScreen> {
         title: _titleController.text,
         author: _authorController.text,
         isbn: _isbnController.text,
-        year: int.tryParse(_yearController.text),
+        publishedDate: int.tryParse(_publishedDateController.text),
         description: _descriptionController.text,
-        firstAppearanceYear: int.tryParse(_yearController.text), // P83b7
       );
       try {
         await _bookService.addBook(book);
@@ -155,11 +154,11 @@ class _AddBookScreenState extends State<AddBookScreen> {
                 },
               ),
               TextFormField(
-                controller: _yearController,
-                decoration: InputDecoration(labelText: 'Year'),
+                controller: _publishedDateController,
+                decoration: InputDecoration(labelText: 'Published Date'),
                 validator: (value) {
                   if (value?.isEmpty ?? true) {
-                    return 'Please enter the year';
+                    return 'Please enter the published date';
                   }
                   return null;
                 },

--- a/lib/screens/book_details_screen.dart
+++ b/lib/screens/book_details_screen.dart
@@ -32,15 +32,9 @@ class BookDetailsScreen extends StatelessWidget {
               style: TextStyle(fontSize: 18),
             ),
             SizedBox(height: 8.0),
-            if (book.year != null)
+            if (book.publishedDate != null)
               Text(
-                'Year: ${book.year}',
-                style: TextStyle(fontSize: 18),
-              ),
-            SizedBox(height: 8.0),
-            if (book.firstAppearanceYear != null)
-              Text(
-                'First Appearance Year: ${book.firstAppearanceYear}',
+                'Published Date: ${book.publishedDate}',
                 style: TextStyle(fontSize: 18),
               ),
             SizedBox(height: 8.0),

--- a/lib/widgets/book_list_item.dart
+++ b/lib/widgets/book_list_item.dart
@@ -39,7 +39,7 @@ class BookListItem extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(book.author),
-              if (book.year != null) Text('Year: ${book.year}'),
+              if (book.publishedDate != null) Text('Published Date: ${book.publishedDate}'),
             ],
           ),
         ),


### PR DESCRIPTION
Rename the `year` property to `publishedDate` and update related methods and constructors in the `Book` class.

- **Book Model Changes:**
  - Rename `year` to `publishedDate`.
  - Update `Book.fromJson` to use `publishedDate` instead of `year`.
  - Update `toJson` method to use `publishedDate` instead of `year`.
  - Update `toString` method to use `publishedDate` instead of `year`.
  - Update `isbn` property to be taken from `industryIdentifiers` in `Book.fromJson`.

- **Add Book Screen Changes:**
  - Rename `_yearController` to `_publishedDateController`.
  - Update `_searchForBook` method to use `publishedDate` instead of `year`.
  - Update `_addBook` method to use `publishedDate` instead of `year`.
  - Update `_searchForBook` method to take `isbn` from `industryIdentifiers`.

- **Book Details Screen Changes:**
  - Rename `year` field to `publishedDate` in `BookDetailsScreen` widget.

- **Book List Item Changes:**
  - Rename `year` field to `publishedDate` in `BookListItem` widget.

