### PR TITLE
Fix delete book functionality

### DIFF
--- a/lib/screens/book_details_screen.dart
+++ b/lib/screens/book_details_screen.dart
@@ -29,7 +29,7 @@ class BookDetailsScreen extends StatelessWidget {
 
     if (shouldDelete == true) {
       await _bookService.deleteBook(book.isbn);
-      Navigator.pop(context);
+      Navigator.pushReplacementNamed(context, '/');
     }
   }
 


### PR DESCRIPTION
Update the `_removeBook` method in `lib/screens/book_details_screen.dart` to navigate to the home screen after deleting a book.

* Replace `Navigator.pop` with `Navigator.pushReplacementNamed` to navigate to the home screen after deletion.

