### PR TITLE
Fix internet permission and display message when no book is found

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="flutter_library_app"
         android:name="${applicationName}"


### PR DESCRIPTION
Add internet permission to the Android manifest file.

* **AndroidManifest.xml**
  - Add `<uses-permission android:name="android.permission.INTERNET"/>` inside the `<manifest>` tag to request internet permission.

