### PR TITLE
Implement singleton BookService using get_it, dispose book_service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,8 +5,10 @@ import 'screens/settings_screen.dart';
 import 'screens/book_details_screen.dart'; // Import the new screen
 import 'models/book.dart'; // Import the Book class
 import 'services/book_service.dart'; // Import the BookService class
+import 'package:get_it/get_it.dart';
 
 void main() {
+  GetIt.I.registerSingleton<BookService>(BookService());
   runApp(MyApp());
 }
 
@@ -19,7 +21,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   int _selectedIndex = 0;
-  final BookService _bookService = BookService();
+  final BookService _bookService = GetIt.I<BookService>();
 
   static final List<Widget> _widgetOptions = <Widget>[
     HomeScreen(),
@@ -41,6 +43,12 @@ class _MyAppState extends State<MyApp> {
 
   void _initializeDatabase() async {
     await _bookService.initDatabase();
+  }
+
+  @override
+  void dispose() {
+    _bookService.database.then((db) => db.close());
+    super.dispose();
   }
 
   @override

--- a/lib/screens/add_book_screen.dart
+++ b/lib/screens/add_book_screen.dart
@@ -4,6 +4,7 @@ import '../models/book.dart';
 import 'package:barcode_scan2/barcode_scan2.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'package:get_it/get_it.dart';
 
 class AddBookScreen extends StatefulWidget {
   const AddBookScreen({super.key});
@@ -19,7 +20,7 @@ class _AddBookScreenState extends State<AddBookScreen> {
   final _isbnController = TextEditingController();
   final _publishedDateController = TextEditingController();
   final _descriptionController = TextEditingController();
-  final BookService _bookService = BookService();
+  final BookService _bookService = GetIt.I<BookService>();
 
   @override
   void dispose() {
@@ -28,6 +29,7 @@ class _AddBookScreenState extends State<AddBookScreen> {
     _isbnController.dispose();
     _publishedDateController.dispose();
     _descriptionController.dispose();
+    _bookService.database.then((db) => db.close());
     super.dispose();
   }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../services/book_service.dart';
+import 'package:get_it/get_it.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -9,7 +10,7 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  final BookService _bookService = BookService();
+  final BookService _bookService = GetIt.I<BookService>();
 
   void _exportLibrary() async {
     // Implement the export functionality here
@@ -21,6 +22,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
     // Implement the import functionality here
     // For example, you can use a file picker to select the import file
     // and then call _bookService.importLibrary(filePath);
+  }
+
+  @override
+  void dispose() {
+    _bookService.database.then((db) => db.close());
+    super.dispose();
   }
 
   @override

--- a/lib/services/book_service.dart
+++ b/lib/services/book_service.dart
@@ -8,6 +8,13 @@ import 'package:http/http.dart' as http;
 class BookService {
   static const String _booksTable = 'books';
   static Database? _database;
+  static final BookService _instance = BookService._internal();
+
+  factory BookService() {
+    return _instance;
+  }
+
+  BookService._internal();
 
   Future<Database> get database async {
     if (_database != null) return _database!;


### PR DESCRIPTION
Implement `BookService` as a singleton using `get_it`.

* **lib/main.dart**
  - Import `get_it` package.
  - Register `BookService` as a singleton in the `main` function.
  - Remove `_bookService` instantiation in `_MyAppState` class.
  - Use `get_it` to access `BookService` in `_MyAppState` class.
  - Override `dispose` method in `_MyAppState` class to close the database.

* **lib/screens/add_book_screen.dart**
  - Import `get_it` package.
  - Remove `_bookService` instantiation in `_AddBookScreenState` class.
  - Use `get_it` to access `BookService` in `_AddBookScreenState` class.
  - Override `dispose` method in `_AddBookScreenState` class to close the database.

* **lib/screens/settings_screen.dart**
  - Import `get_it` package.
  - Remove `_bookService` instantiation in `_SettingsScreenState` class.
  - Use `get_it` to access `BookService` in `_SettingsScreenState` class.
  - Override `dispose` method in `_SettingsScreenState` class to close the database.

* **lib/services/book_service.dart**
  - Implement `BookService` as a singleton.
  - Add a factory constructor and an internal constructor for the singleton pattern.

