### PR TITLE
Fix database closed error when adding a book

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,12 +46,6 @@ class _MyAppState extends State<MyApp> {
   }
 
   @override
-  void dispose() {
-    _bookService.database.then((db) => db.close());
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Book Tracker',

--- a/lib/screens/add_book_screen.dart
+++ b/lib/screens/add_book_screen.dart
@@ -29,7 +29,6 @@ class _AddBookScreenState extends State<AddBookScreen> {
     _isbnController.dispose();
     _publishedDateController.dispose();
     _descriptionController.dispose();
-    _bookService.database.then((db) => db.close());
     super.dispose();
   }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -25,12 +25,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   @override
-  void dispose() {
-    _bookService.database.then((db) => db.close());
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.1+2
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Remove the `dispose` methods that close the database in various files to prevent the `DatabaseException(error database_closed)` error when adding a book.

* **lib/main.dart**
  - Remove the `dispose` method that closes the database.

* **lib/screens/add_book_screen.dart**
  - Remove the `dispose` method that closes the database.

* **lib/screens/settings_screen.dart**
  - Remove the `dispose` method that closes the database.

