### PR TITLE
Add widget tests for current functionalities

### DIFF
--- a/lib/screens/book_details_screen.dart
+++ b/lib/screens/book_details_screen.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import '../models/book.dart';
 import '../services/book_service.dart';
+import 'package:get_it/get_it.dart';
 
 class BookDetailsScreen extends StatelessWidget {
   final Book book;
-  final BookService _bookService = BookService();
+  final BookService _bookService = GetIt.I<BookService>();
 
   BookDetailsScreen({super.key, required this.book});
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/book.dart';
 import '../services/book_service.dart';
 import '../widgets/book_list_item.dart';
+import 'package:get_it/get_it.dart';
 import 'settings_screen.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -12,7 +13,7 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  final BookService _bookService = BookService();
+  final BookService _bookService = GetIt.I<BookService>();
   List<Book> _books = [];
   String _searchQuery = '';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   sqflite: ^2.0.0+4
   path: ^1.8.0
   get_it: ^8.0.3
+  provider: ^6.0.3
 
 dev_dependencies:
   flutter_test:
@@ -54,6 +55,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  mockito: ^5.0.16
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/book_details_screen_test.dart
+++ b/test/book_details_screen_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mockito/annotations.dart';
+import 'package:my_app/main.dart';
+import 'package:my_app/models/book.dart';
+import 'package:my_app/services/book_service.dart';
+import 'package:my_app/screens/book_details_screen.dart';
+
+@GenerateMocks([BookService])
+void main() {
+  group('Book Details Screen Tests', () {
+    late MockBookService mockBookService;
+
+    setUp(() {
+      mockBookService = MockBookService();
+    });
+
+    testWidgets('Test opening book details screen by clicking on a book', (WidgetTester tester) async {
+      when(mockBookService.getBooks()).thenAnswer((_) async => [
+        Book(title: 'Test Book', author: 'Test Author', isbn: '1234567890123'),
+      ]);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BookService>(
+          create: (_) => mockBookService,
+          child: MyApp(),
+        ),
+      );
+
+      await tester.tap(find.text('Test Book'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BookDetailsScreen), findsOneWidget);
+      expect(find.text('Test Book'), findsOneWidget);
+      expect(find.text('Test Author'), findsOneWidget);
+    });
+
+    testWidgets('Test if long description is scrollable', (WidgetTester tester) async {
+      final longDescription = 'A' * 4001;
+      when(mockBookService.getBooks()).thenAnswer((_) async => [
+        Book(title: 'Test Book', author: 'Test Author', isbn: '1234567890123', description: longDescription),
+      ]);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BookService>(
+          create: (_) => mockBookService,
+          child: MyApp(),
+        ),
+      );
+
+      await tester.tap(find.text('Test Book'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(BookDetailsScreen), findsOneWidget);
+      expect(find.text(longDescription), findsOneWidget);
+
+      final scrollableFinder = find.byType(SingleChildScrollView);
+      expect(scrollableFinder, findsOneWidget);
+
+      final scrollable = tester.widget<SingleChildScrollView>(scrollableFinder);
+      expect(scrollable.physics, isNotNull);
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mockito/annotations.dart';
+import 'package:my_app/main.dart';
+import 'package:my_app/models/book.dart';
+import 'package:my_app/services/book_service.dart';
+import 'package:my_app/screens/home_screen.dart';
+import 'package:my_app/screens/add_book_screen.dart';
+import 'package:my_app/screens/settings_screen.dart';
+import 'package:my_app/screens/book_details_screen.dart';
+
+@GenerateMocks([BookService])
+void main() {
+  group('Widget Tests', () {
+    late MockBookService mockBookService;
+
+    setUp(() {
+      mockBookService = MockBookService();
+    });
+
+    testWidgets('Test changing tabs and opening new screens', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BookService>(
+          create: (_) => mockBookService,
+          child: MyApp(),
+        ),
+      );
+
+      expect(find.byType(HomeScreen), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+      expect(find.byType(AddBookScreen), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.settings));
+      await tester.pumpAndSettle();
+      expect(find.byType(SettingsScreen), findsOneWidget);
+    });
+
+    testWidgets('Test adding a book and checking its existence', (WidgetTester tester) async {
+      when(mockBookService.addBook(any)).thenAnswer((_) async => true);
+      when(mockBookService.getBooks()).thenAnswer((_) async => [
+        Book(title: 'Test Book', author: 'Test Author', isbn: '1234567890123'),
+      ]);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BookService>(
+          create: (_) => mockBookService,
+          child: MyApp(),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(Key('titleField')), 'Test Book');
+      await tester.enterText(find.byKey(Key('authorField')), 'Test Author');
+      await tester.enterText(find.byKey(Key('isbnField')), '1234567890123');
+      await tester.tap(find.byKey(Key('submitButton')));
+      await tester.pumpAndSettle();
+
+      verify(mockBookService.addBook(any)).called(1);
+
+      await tester.tap(find.byIcon(Icons.home));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Test Book'), findsOneWidget);
+    });
+
+    testWidgets('Test deleting a book', (WidgetTester tester) async {
+      when(mockBookService.getBooks()).thenAnswer((_) async => [
+        Book(title: 'Test Book', author: 'Test Author', isbn: '1234567890123'),
+      ]);
+      when(mockBookService.deleteBook(any)).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BookService>(
+          create: (_) => mockBookService,
+          child: MyApp(),
+        ),
+      );
+
+      await tester.tap(find.text('Test Book'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.delete));
+      await tester.pumpAndSettle();
+
+      verify(mockBookService.deleteBook('1234567890123')).called(1);
+    });
+
+    testWidgets('Test searching a book by ISBN and checking the result', (WidgetTester tester) async {
+      when(mockBookService.searchBookByNameOrISBN(any)).thenAnswer((_) async => Book(
+        title: 'Harry Potter',
+        author: 'J.K. Rowling',
+        isbn: '9780590353427',
+      ));
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<BookService>(
+          create: (_) => mockBookService,
+          child: MyApp(),
+        ),
+      );
+
+      await tester.enterText(find.byKey(Key('searchField')), '9780590353427');
+      await tester.tap(find.byKey(Key('searchButton')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Harry Potter'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Add widget tests and book details screen tests.

* **Widget Tests**
  - Create a new test file `test/widget_test.dart`.
  - Add a test for changing tabs and opening new screens.
  - Add a test for adding a book and checking its existence.
  - Add a test for deleting a book.
  - Add a test for searching a book by ISBN and checking the result.

* **Book Details Screen Tests**
  - Create a new test file `test/book_details_screen_test.dart`.
  - Add a test for opening book details screen by clicking on a book.
  - Add a test for checking if a long description is scrollable.

