### PR TITLE
Add import and export functionality

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/book_service.dart';
 import 'package:get_it/get_it.dart';
+import 'package:file_picker/file_picker.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -13,15 +14,32 @@ class _SettingsScreenState extends State<SettingsScreen> {
   final BookService _bookService = GetIt.I<BookService>();
 
   void _exportLibrary() async {
-    // Implement the export functionality here
-    // For example, you can use a file picker to select the export location
-    // and then call _bookService.exportLibrary(filePath);
+    String? filePath = await FilePicker.platform.saveFile(
+      dialogTitle: 'Please select an export location:',
+      fileName: 'library.json',
+    );
+
+    if (filePath != null) {
+      await _bookService.exportLibrary(filePath);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Library exported successfully!')),
+      );
+    }
   }
 
   void _importLibrary() async {
-    // Implement the import functionality here
-    // For example, you can use a file picker to select the import file
-    // and then call _bookService.importLibrary(filePath);
+    FilePickerResult? result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['json'],
+    );
+
+    if (result != null && result.files.single.path != null) {
+      String filePath = result.files.single.path!;
+      await _bookService.importLibrary(filePath);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Library imported successfully!')),
+      );
+    }
   }
 
   @override

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -14,30 +14,50 @@ class _SettingsScreenState extends State<SettingsScreen> {
   final BookService _bookService = GetIt.I<BookService>();
 
   void _exportLibrary() async {
-    String? filePath = await FilePicker.platform.saveFile(
-      dialogTitle: 'Please select an export location:',
-      fileName: 'library.json',
-    );
+    try {
+      String? filePath = await FilePicker.platform.saveFile(
+        dialogTitle: 'Please select an export location:',
+        fileName: 'library.json',
+      );
 
-    if (filePath != null) {
-      await _bookService.exportLibrary(filePath);
+      if (filePath != null) {
+        await _bookService.exportLibrary(filePath);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Library exported successfully!')),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Export cancelled.')),
+        );
+      }
+    } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Library exported successfully!')),
+        SnackBar(content: Text('Failed to export library: $e')),
       );
     }
   }
 
   void _importLibrary() async {
-    FilePickerResult? result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['json'],
-    );
+    try {
+      FilePickerResult? result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['json'],
+      );
 
-    if (result != null && result.files.single.path != null) {
-      String filePath = result.files.single.path!;
-      await _bookService.importLibrary(filePath);
+      if (result != null && result.files.single.path != null) {
+        String filePath = result.files.single.path!;
+        await _bookService.importLibrary(filePath);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Library imported successfully!')),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Import cancelled.')),
+        );
+      }
+    } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Library imported successfully!')),
+        SnackBar(content: Text('Failed to import library: $e')),
       );
     }
   }

--- a/lib/services/book_service.dart
+++ b/lib/services/book_service.dart
@@ -91,7 +91,8 @@ class BookService {
     try {
       final books = await getBooks();
       final file = File(filePath);
-      await file.writeAsString(jsonEncode(books.map((b) => b.toJson()).toList()));
+      final jsonBooks = jsonEncode(books.map((b) => b.toJson()).toList());
+      await file.writeAsString(jsonBooks);
     } catch (e) {
       throw Exception('Failed to export library: $e');
     }


### PR DESCRIPTION
Implement export and import functionality for the library.

* Add `file_picker` package import to `lib/screens/settings_screen.dart`.
* Implement `_exportLibrary` method to use `FilePicker.platform.saveFile` for selecting export location and call `_bookService.exportLibrary(filePath)`.
* Implement `_importLibrary` method to use `FilePicker.platform.pickFiles` for selecting import file and call `_bookService.importLibrary(filePath)`.

